### PR TITLE
Add test case for bug "Channel is already registered with another priority"

### DIFF
--- a/packages/Ecotone/tests/Projecting/ProjectingTest.php
+++ b/packages/Ecotone/tests/Projecting/ProjectingTest.php
@@ -10,6 +10,7 @@ namespace Test\Ecotone\Projecting;
 use Ecotone\EventSourcing\Attribute\ProjectionInitialization;
 use Ecotone\Lite\EcotoneLite;
 use Ecotone\Messaging\Attribute\Asynchronous;
+use Ecotone\Messaging\Attribute\Endpoint\Priority;
 use Ecotone\Messaging\Channel\SimpleMessageChannelBuilder;
 use Ecotone\Messaging\Config\ConfigurationException;
 use Ecotone\Messaging\Config\ModulePackageList;
@@ -183,6 +184,28 @@ class ProjectingTest extends TestCase
         $projection = new #[Projection('test')] class {
             #[EventHandler('*')]
             public function handle(array $event): void
+            {
+            }
+        };
+        EcotoneLite::bootstrapFlowTesting(
+            [$projection::class],
+            [$projection],
+            configuration: ServiceConfiguration::createWithDefaults()
+                ->withSkippedModulePackageNames(ModulePackageList::allPackages())
+                ->addExtensionObject(new InMemoryStreamSourceBuilder())
+        );
+    }
+
+    public function test_it_with_event_handler_priority(): void
+    {
+        $projection = new #[Projection('test')] class {
+            #[EventHandler('*')]
+            public function handle(array $event): void
+            {
+            }
+            #[Priority(42)]
+            #[EventHandler('*')]
+            public function handleHighPriority(array $event): void
             {
             }
         };


### PR DESCRIPTION
## Why is this change proposed?
This pull request adds a failing test case to demonstrate a bug introduced in Ecotone v1.256.0.
The bug occurs when a projection mixes event handlers with explicitly defined priority values and handlers without any priority.
In this scenario, Ecotone attempts to register the same channel multiple times with different priority groups, leading to the runtime error:

`RuntimeException: Channel projection_handler_xxx is already registered with another priority`

## Description of Changes
Added a failing test to clearly reproduce the issue.  The test defines an anonymous projection containing:

- One event handler without a priority.
- Another event handler with a defined priority (#[Priority(42)]).
- Bootstrapping Ecotone with this projection triggers the runtime error.

The test passes if the bug is fixed, proving the issue is resolved.

## Pull Request Contribution Terms

- [X] I have read and agree to the contribution terms outlined in [CONTRIBUTING](https://github.com/ecotoneframework/ecotone-dev/blob/main/CONTRIBUTING.md).